### PR TITLE
Patch to allow multiple instances per field group

### DIFF
--- a/acf-justified-image-grid-v5.php
+++ b/acf-justified-image-grid-v5.php
@@ -963,11 +963,14 @@ function get_image_sizes() {
 		}
 	}
 
-	function cmp($a, $b) {
-		if ($a['height'] == $b['height']) {
-			return 0;
+	if (function_exists('cmp')) {
+		} else {
+		function cmp($a, $b) {
+			if ($a['height'] == $b['height']) {
+				return 0;
+			}
+			return ($a['height'] < $b['height']) ? -1 : 1;
 		}
-		return ($a['height'] < $b['height']) ? -1 : 1;
 	}
 
 	uasort($sizes, "cmp");


### PR DESCRIPTION
Fixes issue:

Fatal error: Cannot redeclare cmp() (previously declared in /public_html/wp-content/plugins/ACF-Justified-Image-Grid-master/acf-justified-image-grid-v5.php:966) in /public_html/wp-content/plugins/ACF-Justified-Image-Grid-master/acf-justified-image-grid-v5.php on line 966

Signed-off-by: Andi Elliott <andi.elliott@gmail.com>